### PR TITLE
Updated the Update-UI and fixed pre-release channel not able to get stable updates

### DIFF
--- a/OsuPlayer.Network/GitHubUpdater.cs
+++ b/OsuPlayer.Network/GitHubUpdater.cs
@@ -14,7 +14,7 @@ public static class GitHubUpdater
     /// Checks if the current version is older and needs to be updated
     /// </summary>
     /// <param name="releaseChannel">The release channel to be used</param>
-    public static async Task<(bool, string?, string?)> CheckForUpdates(ReleaseChannels releaseChannel = ReleaseChannels.Stable)
+    public static async Task<UpdateResponse> CheckForUpdates(ReleaseChannels releaseChannel = ReleaseChannels.Stable)
     {
         var curVersion = Assembly.GetEntryAssembly()!.GetName().Version;
 
@@ -22,11 +22,25 @@ public static class GitHubUpdater
 
         var release = await GetLatestRelease(releaseChannel);
 
-        if (release == default) return (false, null, null);
+        if (release == default) return new()
+        {
+            IsNewVersionAvailable = false
+        };
 
-        if (currentVersion != release.TagName) return (true, release.HtmlUrl, release.TagName);
+        if (currentVersion != release.TagName) return new ()
+        {
+            IsNewVersionAvailable = true,
+            HtmlUrl = release.HtmlUrl,
+            IsPrerelease = releaseChannel == ReleaseChannels.PreReleases,
+            Version = release.TagName,
+            ReleaseDate = release.CreatedAt,
+            PatchNotes = await GetLatestPatchNotes(releaseChannel)
+        };
 
-        return (false, null, null);
+        return new UpdateResponse
+        {
+            IsNewVersionAvailable = false
+        };
     }
 
     /// <summary>
@@ -41,8 +55,17 @@ public static class GitHubUpdater
         var releases = await github.Repository.Release.GetAll("osu-player", "osuplayer");
 
         var includePreReleases = releaseChannel == ReleaseChannels.PreReleases;
-        
-        return releases.FirstOrDefault(x => x.Prerelease == includePreReleases);
+
+        Release latestRelease = null;
+
+        foreach (var release in releases.OrderBy(x => x.CreatedAt))
+        {
+            if(release.Prerelease && !includePreReleases) continue;
+
+            latestRelease = release;
+        }
+
+        return latestRelease;
     }
 
     public static async Task<string> GetLatestPatchNotes(ReleaseChannels releaseChannel = ReleaseChannels.Stable)

--- a/OsuPlayer.Network/GitHubUpdater.cs
+++ b/OsuPlayer.Network/GitHubUpdater.cs
@@ -11,9 +11,10 @@ namespace OsuPlayer.Network;
 public static class GitHubUpdater
 {
     /// <summary>
-    /// Checks if the current version is older and needs to be updated
+    /// Checks if an older version is running and if so it will notify the user.
     /// </summary>
     /// <param name="releaseChannel">The release channel to be used</param>
+    /// <returns>a UpdateResponse object</returns>
     public static async Task<UpdateResponse> CheckForUpdates(ReleaseChannels releaseChannel = ReleaseChannels.Stable)
     {
         var curVersion = Assembly.GetEntryAssembly()!.GetName().Version;

--- a/OsuPlayer.Network/UpdateResponse.cs
+++ b/OsuPlayer.Network/UpdateResponse.cs
@@ -1,0 +1,11 @@
+﻿namespace OsuPlayer.Network;
+
+public sealed class UpdateResponse
+{
+    public bool IsNewVersionAvailable { get; set; }
+    public bool IsPrerelease { get; set; }
+    public string? HtmlUrl { get; set; }
+    public string? Version { get; set; }
+    public string? PatchNotes { get; set; }
+    public DateTimeOffset? ReleaseDate { get; set; }
+}

--- a/OsuPlayer.Network/UpdateResponse.cs
+++ b/OsuPlayer.Network/UpdateResponse.cs
@@ -1,5 +1,8 @@
 ﻿namespace OsuPlayer.Network;
 
+/// <summary>
+/// A data structure for an update.
+/// </summary>
 public sealed class UpdateResponse
 {
     public bool IsNewVersionAvailable { get; set; }

--- a/OsuPlayer/Views/UpdateView.axaml
+++ b/OsuPlayer/Views/UpdateView.axaml
@@ -3,6 +3,8 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:views="clr-namespace:OsuPlayer.Views"
+             xmlns:avalonia="clr-namespace:Markdown.Avalonia;assembly=Markdown.Avalonia"
+             xmlns:ctxt="clr-namespace:ColorTextBlock.Avalonia;assembly=ColorTextBlock.Avalonia"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="OsuPlayer.Views.UpdateView">
 
@@ -10,7 +12,7 @@
         <views:UpdateViewModel />
     </Design.DataContext>
 
-    <Grid>
+    <Grid >
         <Panel>
             <ExperimentalAcrylicBorder IsHitTestVisible="False">
                 <ExperimentalAcrylicBorder.Material>
@@ -22,11 +24,19 @@
                 </ExperimentalAcrylicBorder.Material>
             </ExperimentalAcrylicBorder>
         </Panel>
-
-        <StackPanel VerticalAlignment="Center" HorizontalAlignment="Stretch" Spacing="10">
-            <TextBlock Text="UPDATE AVAILABLE" FontSize="64" VerticalAlignment="Center" HorizontalAlignment="Center" />
-            <TextBlock Text="{Binding InfoString}" HorizontalAlignment="Center" FontSize="24" />
-            <Button Content="open github" HorizontalAlignment="Center" Click="Button_OnClick" FontSize="18" />
-        </StackPanel>
+        
+        <Grid RowDefinitions="Auto, *, 50" Margin="5">
+            <TextBlock Grid.Row="0" Text="Look a new osu!player update" FontSize="48"  FontStyle="Italic" VerticalAlignment="Center" HorizontalAlignment="Left" />
+            
+            <avalonia:MarkdownScrollViewer Grid.Row="1" Markdown="{Binding Update.PatchNotes}">
+                <avalonia:MarkdownScrollViewer.Styles>
+                    <Style Selector="ctxt|CTextBlock.Heading2">
+                        <Setter Property="Foreground" Value="White" />
+                    </Style>
+                </avalonia:MarkdownScrollViewer.Styles>
+            </avalonia:MarkdownScrollViewer>
+            
+            <Button Grid.Row="2" Content="open github" HorizontalAlignment="Center" Click="Button_OnClick" FontSize="18" />
+        </Grid>
     </Grid>
 </UserControl>

--- a/OsuPlayer/Views/UpdateView.axaml.cs
+++ b/OsuPlayer/Views/UpdateView.axaml.cs
@@ -18,8 +18,8 @@ public partial class UpdateView : ReactivePlayerControl<UpdateViewModel>
 
     private void Button_OnClick(object? sender, RoutedEventArgs e)
     {
-        if (ViewModel?.UpdateUrl == default) return;
+        if (ViewModel?.Update.HtmlUrl == default) return;
 
-        GeneralExtensions.OpenUrl(ViewModel.UpdateUrl);
+        GeneralExtensions.OpenUrl(ViewModel.Update.HtmlUrl);
     }
 }

--- a/OsuPlayer/Views/UpdateViewModel.cs
+++ b/OsuPlayer/Views/UpdateViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reactive.Disposables;
+using OsuPlayer.Network;
 using OsuPlayer.ViewModels;
 using ReactiveUI;
 
@@ -6,32 +7,18 @@ namespace OsuPlayer.Views;
 
 public class UpdateViewModel : BaseViewModel
 {
-    private string _infoString;
-    private string? _newVersion;
-    private string? _updateUrl;
-
+    public UpdateResponse Update
+    {
+        get => _update;
+        set => this.RaiseAndSetIfChanged(ref _update, value);
+    }
+    
+    private UpdateResponse _update;
+    
     public UpdateViewModel()
     {
         Activator = new ViewModelActivator();
 
         this.WhenActivated(disposables => { Disposable.Create(() => { }).DisposeWith(disposables); });
-    }
-
-    public string InfoString
-    {
-        get => $"Head to GitHub to download v{_newVersion}";
-        set => this.RaiseAndSetIfChanged(ref _infoString, value);
-    }
-
-    public string? UpdateUrl
-    {
-        get => _updateUrl;
-        set => this.RaiseAndSetIfChanged(ref _updateUrl, value);
-    }
-
-    public string? NewVersion
-    {
-        get => _newVersion;
-        set => this.RaiseAndSetIfChanged(ref _newVersion, value);
     }
 }

--- a/OsuPlayer/Windows/MainWindow.axaml.cs
+++ b/OsuPlayer/Windows/MainWindow.axaml.cs
@@ -63,11 +63,14 @@ public partial class MainWindow : ReactivePlayerWindow<MainWindowViewModel>
 #if DEBUG
         // We are ignoring update checks if we are running in debug.
         // The local development version will always be greater than the latest release
-        if (result.IsNewVersionAvailable)
-        {
-            ViewModel.UpdateView.Update = result;
-            ViewModel!.MainView = ViewModel.UpdateView;
-        }
+        
+        // Uncomment code below to force the update UI to show for testing purposes.
+        
+        // if (result.IsNewVersionAvailable)
+        // {
+        //     ViewModel.UpdateView.Update = result;
+        //     ViewModel!.MainView = ViewModel.UpdateView;
+        // }
 #else
         if (result.IsNewVersionAvailable)
         {

--- a/OsuPlayer/Windows/MainWindow.axaml.cs
+++ b/OsuPlayer/Windows/MainWindow.axaml.cs
@@ -63,11 +63,15 @@ public partial class MainWindow : ReactivePlayerWindow<MainWindowViewModel>
 #if DEBUG
         // We are ignoring update checks if we are running in debug.
         // The local development version will always be greater than the latest release
-#else
-        if (result.Item1)
+        if (result.IsNewVersionAvailable)
         {
-            ViewModel.UpdateView.UpdateUrl = result.Item2;
-            ViewModel.UpdateView.NewVersion = result.Item3;
+            ViewModel.UpdateView.Update = result;
+            ViewModel!.MainView = ViewModel.UpdateView;
+        }
+#else
+        if (result.IsNewVersionAvailable)
+        {
+            ViewModel.UpdateView.Update = result;
             ViewModel!.MainView = ViewModel.UpdateView;
         }
 #endif


### PR DESCRIPTION
This issue will close #86 

While changing the UI and testing the display of the patchnotes I noticed. If you use the Pre-Release channel, you won't be able to get stable release updates.