### PR TITLE
Add osu resource dll deletion to osx and windows in publish workflow

### DIFF
--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -110,6 +110,7 @@ jobs:
         RELEASE_VERSION: ${{ steps.get_tag.outputs.TAG }}
       run: |
         dotnet publish -c Release -o ./releases/${{ matrix.release }} -r ${{ matrix.release }} --no-self-contained
+        rm ./releases/${{ matrix.release }}/osu.Game.Resources.dll
 
     - name: Generate artifact
       uses: TheDoctor0/zip-release@0.6.1
@@ -164,6 +165,7 @@ jobs:
         RELEASE_VERSION: ${{ steps.get_tag.outputs.TAG }}
       run: |
         dotnet publish -c Release -o ./releases/${{ matrix.release }} -r ${{ matrix.release }} --no-self-contained
+        rm ./releases/${{ matrix.release }}/osu.Game.Resources.dll
 
     - name: Generate artifact
       uses: TheDoctor0/zip-release@0.6.1


### PR DESCRIPTION
I forgot to add the resource dll deletion in the workflow for these runners :)