### PR TITLE
Fix patch notes regex bug

### DIFF
--- a/OsuPlayer.Network/GitHubUpdater.cs
+++ b/OsuPlayer.Network/GitHubUpdater.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics;
 using System.Globalization;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using Octokit;
 
 namespace OsuPlayer.Network;
@@ -93,11 +94,16 @@ public static class GitHubUpdater
             if (release == default)
                 return "**No patch-notes found**";
 
+            var regex = new Regex(@"( in )([\w\s:\/\.-])*[\d]+");
+            var newBody = regex.Replace(release.Body, "");
+            regex = new Regex(@"(\n?\r?)*[\*]*(Full Changelog)[\*]*:.*$");
+            newBody = regex.Replace(newBody, "");
+
             return $"## {(release.Prerelease ? "pre-release" : "release")} v" + release.TagName + Environment.NewLine
                    + "*released " + release.CreatedAt.ToString("F", new CultureInfo("en-us")) + "*"
                    + Environment.NewLine
                    + Environment.NewLine
-                   + release.Body;
+                   + newBody;
         }
         catch (RateLimitExceededException ex)
         {

--- a/OsuPlayer/Views/SettingsViewModel.cs
+++ b/OsuPlayer/Views/SettingsViewModel.cs
@@ -204,9 +204,6 @@ public class SettingsViewModel : BaseViewModel
 
         if (string.IsNullOrWhiteSpace(latestPatchNotes)) return;
 
-        var regex = new Regex(@"( in )([\w\s:\/\.-])*[\d]+");
-        latestPatchNotes = regex.Replace(latestPatchNotes, "");
-        regex = new Regex(@"(\n?\r?)*[\*]*(Full Changelog)[\*]*:.*$");
-        Patchnotes = regex.Replace(latestPatchNotes, "");
+        Patchnotes = latestPatchNotes;
     }
 }

--- a/OsuPlayer/Views/SettingsViewModel.cs
+++ b/OsuPlayer/Views/SettingsViewModel.cs
@@ -204,7 +204,7 @@ public class SettingsViewModel : BaseViewModel
 
         if (string.IsNullOrWhiteSpace(latestPatchNotes)) return;
 
-        var regex = new Regex(@"( in )([\w\s:\/\.])*[\d]+");
+        var regex = new Regex(@"( in )([\w\s:\/\.-])*[\d]+");
         latestPatchNotes = regex.Replace(latestPatchNotes, "");
         regex = new Regex(@"(\n?\r?)*[\*]*(Full Changelog)[\*]*:.*$");
         Patchnotes = regex.Replace(latestPatchNotes, "");


### PR DESCRIPTION
Removes the pr link from the patch notes again, which was caused by the repo owner name change